### PR TITLE
Android security 11.0.0 release 56

### DIFF
--- a/src/nfa/dm/nfa_dm_main.cc
+++ b/src/nfa/dm/nfa_dm_main.cc
@@ -25,6 +25,7 @@
 
 #include <android-base/stringprintf.h>
 #include <base/logging.h>
+#include <log/log.h>
 
 #include "nfa_api.h"
 #include "nfa_dm_int.h"
@@ -236,6 +237,12 @@ tNFA_STATUS nfa_dm_check_set_config(uint8_t tlv_list_len, uint8_t* p_tlv_list,
     len = *(p_tlv_list + xx + 1);
     p_value = p_tlv_list + xx + 2;
     p_cur_len = nullptr;
+    if (len > (tlv_list_len - xx - 2)) {
+      LOG(ERROR) << StringPrintf("error: invalid TLV length: t:0x%x, l:%d",
+                                 type, len);
+      android_errorWriteLog(0x534e4554, "221216105");
+      return NFA_STATUS_FAILED;
+    }
 
     switch (type) {
       /*

--- a/src/nfc/nfc/nfc_ncif.cc
+++ b/src/nfc/nfc/nfc_ncif.cc
@@ -1511,6 +1511,11 @@ void nfc_ncif_proc_ee_discover_req(uint8_t* p, uint16_t plen) {
   DLOG_IF(INFO, nfc_debug_enabled)
       << StringPrintf("nfc_ncif_proc_ee_discover_req %d len:%d", *p, plen);
 
+  if (!plen) {
+    android_errorWriteLog(0x534e4554, "221856662");
+    return;
+  }
+
   if (*p > NFC_MAX_EE_DISC_ENTRIES) {
     android_errorWriteLog(0x534e4554, "122361874");
     LOG(ERROR) << __func__ << "Exceed NFC_MAX_EE_DISC_ENTRIES";

--- a/src/nfc/tags/ce_t4t.cc
+++ b/src/nfc/tags/ce_t4t.cc
@@ -633,6 +633,7 @@ static void ce_t4t_data_cback(uint8_t conn_id, tNFC_CONN_EVT event,
     } else {
       GKI_freebuf(p_c_apdu);
       ce_t4t_send_status(T4T_RSP_NOT_FOUND);
+      return;
     }
   } else if (ce_cb.mem.t4t.status & CE_T4T_STATUS_WILDCARD_AID_SELECTED) {
     DLOG_IF(INFO, nfc_debug_enabled)


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r56' of https://android.googlesource.com/platform/system/nfc into arrow-11.0

Android security 11.0.0 release 56
Tag: https://android.googlesource.com/platform/system/nfc/+/refs/tags/android-security-11.0.0_r56

Merge cherrypicks of [17245462, 17129429, 17310817] into security-aosp-rvc-release.

Change-Id: [Iddaab5f5a209f73b6892b193b9f5ba7c0840af8e](https://android-review.googlesource.com/#/q/Iddaab5f5a209f73b6892b193b9f5ba7c0840af8e)